### PR TITLE
Add mongdb index for updatedAt by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
-  - '0.10'
+  - 0.10
+  - 0.12
+  - 4
+  - node
+services:
+  - mongodb

--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ schema = new mongoose.Schema {}
 schema.plugin timestamps
 ```
 
-By default, it creates indices for both attributes named `timestamps_created_at` and `timestamps_updated_at`. To override
+By default, it creates indexes for both attributes named `timestamps_created_at` and `timestamps_updated_at`. To override
 this behavior:
 
 ```coffee
-# Creates indices for both attributes by default
+# Creates indexes for both attributes by default
 schema.plugin timestamps
 
-# Does not create indices
-schema.plugin timestamps, createIndices: false
+# Does not create indexes
+schema.plugin timestamps, createIndexes: false
 
 # Only create updatedAt index, descending order
-schema.plugin timestamps, createIndices: {updatedAt: -1}
+schema.plugin timestamps, createIndexes: {updatedAt: -1}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -21,19 +21,24 @@ schema = new mongoose.Schema {}
 schema.plugin timestamps
 ```
 
-By default, it creates indexes for both attributes named `timestamps_created_at` and `timestamps_updated_at`. To override
+## Indexes
+
+By default, it creates an index for `updatedAt` named `timestamps_updated_at`. To override
 this behavior:
 
 ```coffee
-# Creates indexes for both attributes by default
+# Creates indexes for updatedAt by default
 schema.plugin timestamps
 
 # Does not create indexes
 schema.plugin timestamps, createIndexes: false
 
-# Only create updatedAt index, descending order
-schema.plugin timestamps, createIndexes: {updatedAt: -1}
+# Only create createdAt index, descending order
+schema.plugin timestamps, createIndexes: {createdAt: -1}
 ```
+
+Note that it does not create an index on `createdAt`. An index on `createdAt` is redundant with the index already on `_id` which encodes the [document create time
+in the first 4 bytes](https://docs.mongodb.com/manual/reference/bson-types/#objectid).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ schema = new mongoose.Schema {}
 schema.plugin timestamps
 ```
 
+By default, it creates indices for both attributes named `timestamps_created_at` and `timestamps_updated_at`. To override
+this behavior:
+
+```coffee
+# Creates indices for both attributes by default
+schema.plugin timestamps
+
+# Does not create indices
+schema.plugin timestamps, createIndices: false
+
+# Only create updatedAt index, descending order
+schema.plugin timestamps, createIndices: {updatedAt: -1}
+```
+
 ## Contributing
 
 Please follow our [Code of Conduct](https://github.com/goodeggs/goodeggs-mongoose-timestamps/blob/master/CODE_OF_CONDUCT.md)

--- a/src/timestamps.coffee
+++ b/src/timestamps.coffee
@@ -1,9 +1,39 @@
 clock = require 'node-clock'
 
-module.exports = (schema, options) ->
+###
+  Adds createdAt and updatedAt attributes to the document and automatically sets them on create and updates.
+
+  By default creates indices for both attributes. Indexing behavior can be customized with plugin options:
+
+  timestamps = require 'goodeggs-mongoose-timestamps'
+
+  # Creates indices for both attributes by default
+  schema.plugin timestamps
+
+  # Does not create indices
+  schema.plugin timestamps, createIndices: false
+
+  # Only create updatedAt index, descending order
+  schema.plugin timestamps, createIndices: {updatedAt: -1}
+###
+module.exports = (schema, {createIndices} = {}) ->
+  # Default is to create both indices
+  createIndices ?= true
+
+  if createIndices is true
+    createIndices = {createdAt: 1, updatedAt: 1}
+
   schema.add
     updatedAt: {type: Date}
     createdAt: {type: Date}
+
+  if createIndices?.createdAt
+    order = createIndices.createdAt in [-1, 1] and createIndices.createdAt or 1
+    schema.index {createdAt: order}, name: 'timestamp_created_at'
+  if createIndices?.updatedAt
+    order = createIndices.updatedAt in [-1, 1] and createIndices.updatedAt or 1
+    schema.index {updatedAt: order}, name: 'timestamp_updated_at'
+
 
   schema.pre 'save', (next) ->
     now = clock.now()

--- a/src/timestamps.coffee
+++ b/src/timestamps.coffee
@@ -7,21 +7,21 @@ clock = require 'node-clock'
 
   timestamps = require 'goodeggs-mongoose-timestamps'
 
-  # Creates indexes for both attributes by default
+  # Creates indexes for updatedAt by default
   schema.plugin timestamps
 
   # Does not create indexes
   schema.plugin timestamps, createIndexes: false
 
-  # Only create updatedAt index, descending order
-  schema.plugin timestamps, createIndexes: {updatedAt: -1}
+  # Only create createdAt index, descending order
+  schema.plugin timestamps, createIndexes: {createdAt: -1}
 ###
 module.exports = (schema, {createIndexes} = {}) ->
   # Default is to create both indexes
   createIndexes ?= true
 
   if createIndexes is true
-    createIndexes = {createdAt: 1, updatedAt: 1}
+    createIndexes = {updatedAt: 1}
 
   schema.add
     updatedAt: {type: Date}

--- a/src/timestamps.coffee
+++ b/src/timestamps.coffee
@@ -3,35 +3,35 @@ clock = require 'node-clock'
 ###
   Adds createdAt and updatedAt attributes to the document and automatically sets them on create and updates.
 
-  By default creates indices for both attributes. Indexing behavior can be customized with plugin options:
+  By default creates indexes for both attributes. Indexing behavior can be customized with plugin options:
 
   timestamps = require 'goodeggs-mongoose-timestamps'
 
-  # Creates indices for both attributes by default
+  # Creates indexes for both attributes by default
   schema.plugin timestamps
 
-  # Does not create indices
-  schema.plugin timestamps, createIndices: false
+  # Does not create indexes
+  schema.plugin timestamps, createIndexes: false
 
   # Only create updatedAt index, descending order
-  schema.plugin timestamps, createIndices: {updatedAt: -1}
+  schema.plugin timestamps, createIndexes: {updatedAt: -1}
 ###
-module.exports = (schema, {createIndices} = {}) ->
-  # Default is to create both indices
-  createIndices ?= true
+module.exports = (schema, {createIndexes} = {}) ->
+  # Default is to create both indexes
+  createIndexes ?= true
 
-  if createIndices is true
-    createIndices = {createdAt: 1, updatedAt: 1}
+  if createIndexes is true
+    createIndexes = {createdAt: 1, updatedAt: 1}
 
   schema.add
     updatedAt: {type: Date}
     createdAt: {type: Date}
 
-  if createIndices?.createdAt
-    order = createIndices.createdAt in [-1, 1] and createIndices.createdAt or 1
+  if createIndexes?.createdAt
+    order = createIndexes.createdAt in [-1, 1] and createIndexes.createdAt or 1
     schema.index {createdAt: order}, name: 'timestamp_created_at'
-  if createIndices?.updatedAt
-    order = createIndices.updatedAt in [-1, 1] and createIndices.updatedAt or 1
+  if createIndexes?.updatedAt
+    order = createIndexes.updatedAt in [-1, 1] and createIndexes.updatedAt or 1
     schema.index {updatedAt: order}, name: 'timestamp_updated_at'
 
 

--- a/test/timestamps.test.coffee
+++ b/test/timestamps.test.coffee
@@ -10,21 +10,51 @@ mongoose.connect('mongodb://localhost/mongoose_timestamps')
 schema = new mongoose.Schema
   data: String
 schema.plugin timestamps
-TestObject = mongoose.model('TestTimestamps', schema)
+TestTimestamps = mongoose.model('TestTimestamps', schema)
+
+schemaWithoutIndices =
+  schema = new mongoose.Schema
+    data: String
+schemaWithoutIndices.plugin timestamps, createIndices: false
+TestTimestampsWithoutIndices = mongoose.model('TestTimestampsWithoutIndices', schemaWithoutIndices)
+
+schemaWithCustomizedIndices =
+  schema = new mongoose.Schema
+    data: String
+schemaWithCustomizedIndices.plugin timestamps, createIndices: {updatedAt: -1}
+TestTimestampsWithCustomizedIndices = mongoose.model('TestTimestampsWithCustomizedIndices', schemaWithCustomizedIndices)
 
 
 describe 'timestamps', ->
 
   beforeEach (done) ->
-    TestObject.remove(done)
+    TestTimestamps.remove(done)
 
   describe 'create', ->
 
     it 'sets timestamps', (done) ->
-      TestObject.create {}, (err, created) ->
+      TestTimestamps.create {}, (err, created) ->
         expect(created.createdAt instanceof Date).to.be.true
         expect(created.updatedAt instanceof Date).to.be.true
         expect(created.createdAt).to.eql(created.updatedAt)
+        done(err)
+
+    it 'creates indices by default', (done) ->
+      TestTimestamps.collection.getIndexes (err, indexes) ->
+        expect(indexes.timestamp_created_at).to.be.ok
+        expect(indexes.timestamp_updated_at).to.be.ok
+        done(err)
+
+    it 'does not create indices if disabled', (done) ->
+      TestTimestampsWithoutIndices.collection.getIndexes (err, indexes) ->
+        expect(indexes.timestamp_created_at).to.not.be.ok
+        expect(indexes.timestamp_updated_at).to.not.be.ok
+        done(err)
+
+    it 'customizes indices', (done) ->
+      TestTimestampsWithCustomizedIndices.collection.getIndexes (err, indexes) ->
+        expect(indexes.timestamp_created_at).to.not.be.ok
+        expect(indexes.timestamp_updated_at).to.be.ok
         done(err)
 
   describe 'update', ->
@@ -33,7 +63,7 @@ describe 'timestamps', ->
     beforeEach (done) ->
       @sinon.stub(clock, 'now') unless clock.now.returns
       clock.now.returns clock.pacific '2012-04-01 12:00'
-      TestObject.create {}, (err, obj) ->
+      TestTimestamps.create {}, (err, obj) ->
         created = obj
         expect(created.createdAt).to.eql new Date(clock.pacific '2012-04-01 12:00')
         done(err)

--- a/test/timestamps.test.coffee
+++ b/test/timestamps.test.coffee
@@ -12,17 +12,17 @@ schema = new mongoose.Schema
 schema.plugin timestamps
 TestTimestamps = mongoose.model('TestTimestamps', schema)
 
-schemaWithoutIndices =
+schemaWithoutIndexes =
   schema = new mongoose.Schema
     data: String
-schemaWithoutIndices.plugin timestamps, createIndices: false
-TestTimestampsWithoutIndices = mongoose.model('TestTimestampsWithoutIndices', schemaWithoutIndices)
+schemaWithoutIndexes.plugin timestamps, createIndexes: false
+TestTimestampsWithoutIndexes = mongoose.model('TestTimestampsWithoutIndexes', schemaWithoutIndexes)
 
-schemaWithCustomizedIndices =
+schemaWithCustomizedIndexes =
   schema = new mongoose.Schema
     data: String
-schemaWithCustomizedIndices.plugin timestamps, createIndices: {updatedAt: -1}
-TestTimestampsWithCustomizedIndices = mongoose.model('TestTimestampsWithCustomizedIndices', schemaWithCustomizedIndices)
+schemaWithCustomizedIndexes.plugin timestamps, createIndexes: {updatedAt: -1}
+TestTimestampsWithCustomizedIndexes = mongoose.model('TestTimestampsWithCustomizedIndexes', schemaWithCustomizedIndexes)
 
 
 describe 'timestamps', ->
@@ -39,20 +39,20 @@ describe 'timestamps', ->
         expect(created.createdAt).to.eql(created.updatedAt)
         done(err)
 
-    it 'creates indices by default', (done) ->
+    it 'creates indexes by default', (done) ->
       TestTimestamps.collection.getIndexes (err, indexes) ->
         expect(indexes.timestamp_created_at).to.be.ok
         expect(indexes.timestamp_updated_at).to.be.ok
         done(err)
 
-    it 'does not create indices if disabled', (done) ->
-      TestTimestampsWithoutIndices.collection.getIndexes (err, indexes) ->
+    it 'does not create indexes if disabled', (done) ->
+      TestTimestampsWithoutIndexes.collection.getIndexes (err, indexes) ->
         expect(indexes.timestamp_created_at).to.not.be.ok
         expect(indexes.timestamp_updated_at).to.not.be.ok
         done(err)
 
-    it 'customizes indices', (done) ->
-      TestTimestampsWithCustomizedIndices.collection.getIndexes (err, indexes) ->
+    it 'customizes indexes', (done) ->
+      TestTimestampsWithCustomizedIndexes.collection.getIndexes (err, indexes) ->
         expect(indexes.timestamp_created_at).to.not.be.ok
         expect(indexes.timestamp_updated_at).to.be.ok
         done(err)


### PR DESCRIPTION
Used in ETL processes to find incremental updates.

Doing an incremental updates in our ETL scripts for `order_items` takes minutes without an index on `updatedAt` and less than 100ms with the index.

After discussion with a few members of the team, I'm changing the initial proposal in this PR to always index updatedAt and allowing for opt out and customization from there. The rationale is that on important large collections (the ones that we would be concerned about the performance impact of adding another index) we are almost certainly going to need an index on `updatedAt` so that we can efficiently pull the data into our data warehouse.

By default, indexes defined in Mongoose are created in the background at connection time if they do not exist already so one time performance impact of rolling out this change should be minimal.
