### PR TITLE
Supporting model.update (non-bulk)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
-  - 4
-  - node
+  - "4.5.0"
 services:
   - mongodb

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "coffee-script": ">=1.8.x",
     "mocha": "~1.x.x",
-    "mongoose": "~3.8.21",
+    "mongoose": "~3.8.23",
     "chai": "~1.10.0",
     "sinon": "~1.12.2",
     "mocha-sinon": "~1.1.4"

--- a/src/timestamps.coffee
+++ b/src/timestamps.coffee
@@ -41,3 +41,8 @@ module.exports = (schema, {createIndexes} = {}) ->
     @updatedAt = now if @isNew or @isModified()
     next()
 
+  schema.pre 'update', (next, updates) ->
+    if typeof updates is 'object' and Object.keys(updates).length
+      now = new Date clock.now()
+      updates.updatedAt = now
+    next()


### PR DESCRIPTION
As a step towards #3, this causes `model.update` to touch `updatedAt`.

Although this PR won't give us the desired behavior on `Model.update` (bulk-updating) methods without upgrading to mongoose 4.0, we can add support for `model.update` on instances, which should help mitigate some of the ETL incremental-update pain we're having.

cc @brycefisher @asalant 