### PR TITLE
Use mongoose 4 schema option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # goodeggs-mongoose-timestamps
 
-Adds createdAt and updatedAt fields to any schema.
-
-Uses `node-clock` internally so stubbing `clock.now` will determine time value used for model timestamps.
+Adds createdAt and updatedAt fields to any schema using Mongoose's built-in [timestamps schema option](http://mongoosejs.com/docs/guide.html#timestamps).
 
 [![NPM version](http://img.shields.io/npm/v/goodeggs-mongoose-timestamps.svg?style=flat-square)](https://www.npmjs.org/package/goodeggs-mongoose-timestamps)
 [![Build Status](http://img.shields.io/travis/goodeggs/goodeggs-mongoose-timestamps.svg?style=flat-square)](https://travis-ci.org/goodeggs/goodeggs-mongoose-timestamps)
@@ -39,6 +37,10 @@ schema.plugin timestamps, createIndexes: {createdAt: -1}
 
 Note that it does not create an index on `createdAt`. An index on `createdAt` is redundant with the index already on `_id` which encodes the [document create time
 in the first 4 bytes](https://docs.mongodb.com/manual/reference/bson-types/#objectid).
+
+## Testing
+
+To stub the values used to timestamp Mongoose objects, use [`sinon.useFakeTimers`](http://sinonjs.org/docs/#clock-api).
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
   "homepage": "https://github.com/goodeggs/goodeggs-mongoose-timestamps",
   "bugs": "https://github.com/goodeggs/goodeggs-mongoose-timestamps/issues",
   "dependencies": {
-    "node-clock": "~0.1.1"
   },
   "devDependencies": {
     "coffee-script": ">=1.8.x",
     "mocha": "~1.x.x",
-    "mongoose": "~3.8.23",
+    "mongoose": ">=4.4.7",
     "chai": "~1.10.0",
     "sinon": "~1.12.2",
-    "mocha-sinon": "~1.1.4"
+    "mocha-sinon": "~1.1.4",
+    "node-clock": "~0.1.1"
   },
   "scripts": {
     "compile": "coffee --bare --compile --output lib/ src/",

--- a/src/timestamps.coffee
+++ b/src/timestamps.coffee
@@ -1,7 +1,6 @@
-clock = require 'node-clock'
-
 ###
   Adds createdAt and updatedAt attributes to the document and automatically sets them on create and updates.
+  Uses built-in Mongoose support for creating and updating timestamps (http://mongoosejs.com/docs/guide.html#timestamps).
 
   By default creates indexes for both attributes. Indexing behavior can be customized with plugin options:
 
@@ -16,33 +15,27 @@ clock = require 'node-clock'
   # Only create createdAt index, descending order
   schema.plugin timestamps, createIndexes: {createdAt: -1}
 ###
-module.exports = (schema, {createIndexes} = {}) ->
-  # Default is to create both indexes
+module.exports = (schema, options = {}) ->
+  # Default is to create index on updatedAt
+  createIndexes = options.createIndexes
   createIndexes ?= true
 
   if createIndexes is true
     createIndexes = {updatedAt: 1}
 
-  schema.add
-    updatedAt: {type: Date}
-    createdAt: {type: Date}
+  # Use built-in Mongoose support for timestamps (http://mongoosejs.com/docs/guide.html#timestamps)
+  # First available in Mongoose 4.4.7 (https://github.com/Automattic/mongoose/blob/master/History.md#447--2016-03-11)
+  schema.set 'timestamps', true
 
+  # Index createdAt, but only when the schema is the root schema (not embedded in another document)
   if createIndexes?.createdAt
     order = createIndexes.createdAt in [-1, 1] and createIndexes.createdAt or 1
-    schema.index {createdAt: order}
+    schema.on 'init', (modelCls) ->
+      modelCls.collection.ensureIndex { createdAt: order }, { background: true, safe: true }
+
+  # Index updatedAt, but only when the schema is the root schema (not embedded in another document)
   if createIndexes?.updatedAt
     order = createIndexes.updatedAt in [-1, 1] and createIndexes.updatedAt or 1
-    schema.index {updatedAt: order}
+    schema.on 'init', (modelCls) ->
+      modelCls.collection.ensureIndex { updatedAt: order }, { background: true, safe: true }
 
-
-  schema.pre 'save', (next) ->
-    now = clock.now()
-    @createdAt = now if @isNew
-    @updatedAt = now if @isNew or @isModified()
-    next()
-
-  schema.pre 'update', (next, updates) ->
-    if typeof updates is 'object' and Object.keys(updates).length
-      now = new Date clock.now()
-      updates.updatedAt = now
-    next()


### PR DESCRIPTION
Switches to using `{timestamps: true}` Mongoose schema option to pick up all the nice bulk update support.