### PR TITLE
Remove safe true property

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "homepage": "https://github.com/goodeggs/goodeggs-mongoose-timestamps",
   "bugs": "https://github.com/goodeggs/goodeggs-mongoose-timestamps/issues",
-  "dependencies": {},
+  "dependencies": {
+    "mongoose": "^4.13.18"
+  },
   "devDependencies": {
     "coffee-script": ">=1.8.x",
     "mocha": "~1.x.x",

--- a/package.json
+++ b/package.json
@@ -17,17 +17,14 @@
   },
   "homepage": "https://github.com/goodeggs/goodeggs-mongoose-timestamps",
   "bugs": "https://github.com/goodeggs/goodeggs-mongoose-timestamps/issues",
-  "dependencies": {
-    "mongoose": "^4.13.18"
-  },
   "devDependencies": {
+    "chai": "~1.10.0",
     "coffee-script": ">=1.8.x",
     "mocha": "~1.x.x",
-    "mongoose": ">=4.4.7",
-    "chai": "~1.10.0",
-    "sinon": "~1.12.2",
     "mocha-sinon": "~1.1.4",
-    "node-clock": "~0.1.1"
+    "mongoose": "^4.13.18",
+    "node-clock": "~0.1.1",
+    "sinon": "~1.12.2"
   },
   "scripts": {
     "compile": "coffee --bare --compile --output lib/ src/",

--- a/src/timestamps.coffee
+++ b/src/timestamps.coffee
@@ -31,11 +31,11 @@ module.exports = (schema, options = {}) ->
   if createIndexes?.createdAt
     order = createIndexes.createdAt in [-1, 1] and createIndexes.createdAt or 1
     schema.on 'init', (modelCls) ->
-      modelCls.collection.ensureIndex { createdAt: order }, { background: true, safe: true }
+      modelCls.collection.ensureIndex { createdAt: order }, { background: true}
 
   # Index updatedAt, but only when the schema is the root schema (not embedded in another document)
   if createIndexes?.updatedAt
     order = createIndexes.updatedAt in [-1, 1] and createIndexes.updatedAt or 1
     schema.on 'init', (modelCls) ->
-      modelCls.collection.ensureIndex { updatedAt: order }, { background: true, safe: true }
+      modelCls.collection.ensureIndex { updatedAt: order }, { background: true }
 


### PR DESCRIPTION
MongoDB enforces stricter validation for indexes, so `safe: true` no longer a valid field. https://docs.mongodb.com/manual/release-notes/3.4-compatibility/#stricter-validation-of-collection-and-index-specifications