### PR TITLE
release: v2.1.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
     "prepublish": "npm run compile",
     "pretest": "npm run compile",
     "test": "mocha"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-mongoose-timestamps",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Adds createdAt and updatedAt fields to any schema",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [


### PR DESCRIPTION
- configure NPM per latest Good Eggs practices
- release changes from https://github.com/goodeggs/goodeggs-mongoose-timestamps/pull/7

(published to registry locally, since this library isn't set up to publish from CI, and it's deprecated so isn't worth setting up)